### PR TITLE
Fix TOC integration.

### DIFF
--- a/page.go
+++ b/page.go
@@ -1,7 +1,5 @@
 package main
 
-import "github.com/yuin/goldmark/ast"
-
 // The table of contents consists of an array of these
 // dudes.
 type TOCEntry struct {
@@ -66,9 +64,6 @@ type Page struct {
 	// List of assets to be published; any graphics files, etc. in
 	// the local directory
 	assets []string
-
-	// The goldmark AST node representing the parsed markdown source
-	mdNode ast.Node
 }
 
 // Area could be, say, a header:

--- a/toc.go
+++ b/toc.go
@@ -10,7 +10,8 @@ import (
 // generateTOC reads the Markdown source and returns a string
 // array containing each header and its level in the document.
 func (App *App) generateTOC(level int) {
-	tocs, err := extractTOCs(App.goldmark.Renderer(), App.Page.mdNode, App.Page.markdownStart)
+	node := App.markdownAST(App.Page.markdownStart)
+	tocs, err := extractTOCs(App.newGoldmark().Renderer(), node, App.Page.markdownStart)
 	if err != nil {
 		App.QuitError(errCode("0901", err.Error()))
 	}

--- a/toc_test.go
+++ b/toc_test.go
@@ -8,6 +8,43 @@ import (
 	"testing"
 )
 
+func Test_generateTOC(t *testing.T) {
+	tests := []struct {
+		mdSrc string
+		level int
+		want  []TOCEntry
+	}{
+		{texts.Dedent(`
+		     # h1.1
+		     body
+		     ## h2.1
+		`), 2, []TOCEntry{{"h1.1", 1}, {"h2.1", 2}}},
+		{texts.Dedent(`
+		     # h1.1 *foo* bar
+		     body
+		     ## h2.1
+		     ## h2.2
+		     ### h3.1
+		     # h1.2
+		`), 2, []TOCEntry{{"h1.1 <em>foo</em> bar", 1}, {"h2.1", 2},
+			{"h2.2", 2}, {"h1.2", 1}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.mdSrc, func(t *testing.T) {
+			app := App{
+				Site: &Site{},
+				Page: &Page{
+					markdownStart: []byte(tt.mdSrc),
+				},
+			}
+			app.generateTOC(tt.level)
+			if diff := cmp.Diff(tt.want, app.Page.TOC); diff != "" {
+				t.Errorf("extractTOCs() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func Test_extractTOCs(t *testing.T) {
 	gm := goldmark.New()
 	tests := []struct {


### PR DESCRIPTION
Make accessing goldmark object more defensive by moving it to a function. If we need to optimize we can cache the object but constructing the Goldmark object should be pretty cheap.