### PR TITLE
Fix index out of bounds for infer title

### DIFF
--- a/pkg/mdext/title.go
+++ b/pkg/mdext/title.go
@@ -1,6 +1,9 @@
 package mdext
 
-import "github.com/yuin/goldmark/ast"
+import (
+	"github.com/yuin/goldmark/ast"
+	"strconv"
+)
 
 // InferTitle finds the most-likely title for the markdown document.
 // Returns the empty string if no headers exist in the document.
@@ -17,8 +20,12 @@ func InferTitle(root ast.Node, mdSrc []byte) string {
 		}
 
 		h := n.(*ast.Heading)
-		if headers[h.Level] == nil {
-			headers[h.Level] = h
+		if h.Level < 1 || 6 < h.Level {
+			panic("invalid heading level: " + strconv.Itoa(h.Level))
+		}
+		// Subtract 1 to convert from 1-based headers to 0-based slices.
+		if headers[h.Level-1] == nil {
+			headers[h.Level-1] = h
 		}
 		// Skip children because headings can't contain other headings.
 		return ast.WalkSkipChildren, nil

--- a/pkg/mdext/title_test.go
+++ b/pkg/mdext/title_test.go
@@ -28,6 +28,9 @@ func TestInferTitle(t *testing.T) {
 		     ## h2.1
 		     # h1.1 *foo* bar
 		`), "h1.1 foo bar"},
+		{texts.Dedent(`
+		     ###### h6.1
+		`), "h6.1"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.mdSrc, func(t *testing.T) {


### PR DESCRIPTION
Convert from header 1-based indexing to slice 0-based indexing.

Closes #13.